### PR TITLE
Updated the scoreboard design

### DIFF
--- a/app/assets/stylesheets/scoreboards/_show.scss
+++ b/app/assets/stylesheets/scoreboards/_show.scss
@@ -79,7 +79,7 @@ $false-border-margin: 32px;
   background-color: darken($blue, 15);
 
   &.league-match {
-    background-color: darken($green, 10);
+    background-color: darken($green, 12%);
   }
 }
 
@@ -107,22 +107,29 @@ $false-border-margin: 32px;
 
 .scoreboard-league-match {
   position: absolute;
+  top: 0;
   width: 100%;
   text-align: center;
   opacity: 0.5;
   color: white;
-  font-size: modular-scale(5);
+  font-size: modular-scale(4);
+  font-weight: bold;
+  letter-spacing: 0.025em;
+  line-height: 2;
 }
 
 .scoreboard-instructions {
   position: absolute;
-  bottom: 16px;
+  bottom: 24px + $false-border-margin;
   font-size: modular-scale(3);
   width: 100%;
   text-align: center;
   line-height: 1.2;
   color: $yellow;
   text-shadow: 4px 4px 0 rgba(0, 0, 0, 0.25);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
 
   -webkit-animation-name: blinker;
   -webkit-animation-iteration-count: infinite;

--- a/app/assets/stylesheets/scoreboards/_show.scss
+++ b/app/assets/stylesheets/scoreboards/_show.scss
@@ -68,7 +68,7 @@ $bottom-bar-height: 120px;
   position: absolute;
   top: 0;
   right: 0;
-  bottom: $bottom-bar-height;
+  bottom: 0;
   left: 0;
   background-color: darken($blue, 15);
 
@@ -122,6 +122,16 @@ $bottom-bar-height: 120px;
   -webkit-animation-iteration-count: infinite;
   -moz-animation-timing-function: linear;
   -webkit-animation-duration: 1s;
+}
+
+.scoreboard-false-border {
+  border: 5px solid white;
+  position: absolute;
+  $false-border-margin: 32px;
+  top: $false-border-margin;
+  right: $false-border-margin;
+  bottom: $false-border-margin;
+  left: $false-border-margin;
 }
 
 .scoreboard-home-player-avatar,

--- a/app/assets/stylesheets/scoreboards/_show.scss
+++ b/app/assets/stylesheets/scoreboards/_show.scss
@@ -1,4 +1,5 @@
 $bottom-bar-height: 120px;
+$false-border-margin: 32px;
 
 .scoreboard {
   position: fixed;
@@ -8,15 +9,13 @@ $bottom-bar-height: 120px;
 
 .scoreboard-player {
   position: absolute;
-  width: 50%;
-  height: $bottom-bar-height;
+  height: 100%;
   bottom: 0;
-  color: $dark-grey;
-  background-color: $off-white;
+  color: white;
+  width: 45%;
 
   &.has-service {
-    color: $off-white;
-    background-color: $blue;
+    width: 55%;
   }
 }
 
@@ -24,43 +23,50 @@ $bottom-bar-height: 120px;
 .scoreboard-home-player { right: 0; }
 
 .scoreboard-player-name {
-  font-size: modular-scale(5);
+  position: absolute;
+  bottom: 0;
+  font-size: modular-scale(3);
   line-height: $bottom-bar-height;
   padding: 0 modular-scale(2);
-  text-shadow: 2px 2px 0 rgba(0, 0, 0, 0.15);
+  $player-name-shadow: 0 0 16px $blue;
+  text-shadow: $player-name-shadow, $player-name-shadow, $player-name-shadow;
+  text-align: center;
+  font-weight: 800;
+  opacity: 0.75;
+  @include transition(ease-in 250ms);
 
-  .scoreboard-home-player & {
-    text-align: left;
+  // Hacks to make the player names centered on the images which are in a
+  // larger container.
+  width: calc(100% + #{$false-border-margin});
+  .scoreboard-away-player & { left:  -$false-border-margin; }
+  .scoreboard-home-player & { right: -$false-border-margin; }
+
+  .has-service & {
+    font-size: modular-scale(5);
+    bottom: 9px;
+    opacity: 1;
   }
 
-  .scoreboard-away-player & {
-    text-align: right;
+  .message-present & {
+    opacity: 0.25;
   }
 }
 
 .scoreboard-player-score {
   position: absolute;
-  bottom: 0;
-  font-size: modular-scale(10);
+  top: 0;
+  font-size: modular-scale(9);
+  font-weight: 800;
   line-height: 1;
-  text-shadow: 5px 5px 0 rgba(0, 0, 0, 0.15);
-  padding: 0 modular-scale(2);
-  text-align: center;
-  min-width: 375px;
-  background-color: $off-white;
-
-  .has-service & {
-    background-color: $blue;
-  }
+  padding: 0 modular-scale(5);
+  line-height: 1.4;
 
   .scoreboard-home-player & {
     right: 0;
-    border-radius: modular-scale(2) 0 0 0;
   }
 
   .scoreboard-away-player & {
     left: 0;
-    border-radius: 0 modular-scale(2) 0 0;
   }
 }
 
@@ -82,7 +88,7 @@ $bottom-bar-height: 120px;
   top: 50%;
   left: 50%;
   @include transform(translate(-50%, -50%));
-  font-size: modular-scale(7);
+  font-size: modular-scale(6);
   width: 100%;
   max-height: 100%;
   padding: 0 modular-scale(7);
@@ -127,7 +133,6 @@ $bottom-bar-height: 120px;
 .scoreboard-false-border {
   border: 5px solid white;
   position: absolute;
-  $false-border-margin: 32px;
   top: $false-border-margin;
   right: $false-border-margin;
   bottom: $false-border-margin;
@@ -138,14 +143,20 @@ $bottom-bar-height: 120px;
 .scoreboard-away-player-avatar {
   position: absolute;
   top: 0;
-  width: 50%;
   height: 100%;
   background-repeat: none;
-  background-size: contain;
+  background-size: 100% auto;
   background-position: 50% 100%;
   background-repeat: no-repeat;
   opacity: 1.0;
-  @include transition(opacity 200ms ease-out);
+  @include transition(250ms ease-out);
+  opacity: 0.5;
+  width: 45%;
+
+  &.has-service {
+    width: 55%;
+    opacity: 1;
+  }
 
   .message-present & {
     opacity: 0.25;

--- a/app/views/scoreboards/show.html.haml
+++ b/app/views/scoreboards/show.html.haml
@@ -6,13 +6,14 @@
     .scoreboard-message
     .scoreboard-instructions
 
-  .scoreboard-player.scoreboard-away-player
-    .scoreboard-player-name.scoreboard-away-player-name
-    .scoreboard-player-score.scoreboard-away-player-score
+  .scoreboard-false-border
+    .scoreboard-player.scoreboard-away-player
+      .scoreboard-player-name.scoreboard-away-player-name
+      .scoreboard-player-score.scoreboard-away-player-score
 
-  .scoreboard-player.scoreboard-home-player
-    .scoreboard-player-name.scoreboard-home-player-name
-    .scoreboard-player-score.scoreboard-home-player-score
+    .scoreboard-player.scoreboard-home-player
+      .scoreboard-player-name.scoreboard-home-player-name
+      .scoreboard-player-score.scoreboard-home-player-score
 
-  .scoreboard-league-match
-    LEAGUE MATCH
+    .scoreboard-league-match
+      LEAGUE MATCH

--- a/app/webpack/scoreboard.js
+++ b/app/webpack/scoreboard.js
@@ -16,7 +16,7 @@ $(() => {
     .map('.comment')
     .map((message) => !!message)
     .assign(
-      $('.scoreboard-message-area'),
+      $('.scoreboard'),
       'toggleClass',
       'message-present'
     );
@@ -40,14 +40,14 @@ $(() => {
   ongoingMatch
     .map('.away_player_service')
     .assign(
-      $('.scoreboard-away-player'),
+      $('.scoreboard-away-player, .scoreboard-away-player-avatar'),
       'toggleClass',
       'has-service'
     );
   ongoingMatch
     .map('.home_player_service')
     .assign(
-      $('.scoreboard-home-player'),
+      $('.scoreboard-home-player, .scoreboard-home-player-avatar'),
       'toggleClass',
       'has-service'
     );

--- a/lib/tasks/porkchop.rake
+++ b/lib/tasks/porkchop.rake
@@ -2,7 +2,7 @@ namespace :porkchop do
   desc "Pretend someone is pressing buttons on the table"
   task press_buttons: [:environment] do
     loop do
-      sleep rand(0.2..0.8)
+      sleep rand(2..5)
       match = PingPong::Match.new(Match.ongoing.first)
       controls = PingPong::TableControls.new(match)
       case rand(2)

--- a/spec/features/scoreboard_spec.rb
+++ b/spec/features/scoreboard_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe "scoreboard page" do
     expect(page).to have_content(home.name)
     expect(page).to have_content(away.name)
     expect(page).to have_content("01:30")
-    expect(page).to have_content("Select first service")
+    expect(page).to have_content("SELECT FIRST SERVICE")
 
     table.home_button
     expect(page).to have_content("This is the first match between these players")
     expect(page).to have_css('.scoreboard-home-player.has-service')
-    expect(page).to have_no_content("Select first service")
+    expect(page).to have_no_content("SELECT FIRST SERVICE")
 
     table.away_button
     table.home_button
@@ -41,7 +41,7 @@ RSpec.describe "scoreboard page" do
     expect(page).to have_content('Game point')
     table.home_button
 
-    expect(page).to have_content('Press to finalize')
+    expect(page).to have_content('PRESS TO FINALIZE')
     table.home_button
 
     # blank page again


### PR DESCRIPTION
![new1](https://cloud.githubusercontent.com/assets/471667/13345570/a4a9e724-dc14-11e5-8367-6abeecf4fa33.png)
![new2](https://cloud.githubusercontent.com/assets/471667/13345571/a4a9cfa0-dc14-11e5-808e-3a86dec439c8.png)
![new3](https://cloud.githubusercontent.com/assets/471667/13345572/a4bf193c-dc14-11e5-9233-7306dec90656.png)
![new4](https://cloud.githubusercontent.com/assets/471667/13345573/a4c196b2-dc14-11e5-92bc-e340c718803d.png)

Feedback welcome. Mostly looking to figure out a way to make the current player more obvious, but not sure where I can use colour nicely with this setup. I may resort to using the blue/red/white them on the bg, maybe do something animated at cool.

As a "wouldn't it be cool" note: what if we had LEDs on the table edge or something that indicated service. @jhawthorn make me that, then the scoreboard could be a little more minimal like this without having to so obviously indicate service like the current one.
