### PR TITLE
Add various directories to .slugignore

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,5 @@
+/tmp
+/spec
+/app/assets
+/vendor/assets
+/node_modules


### PR DESCRIPTION
We don't need to include the sources for our assets in the compiled
application slug. This includes the npm_modules

This should give us a faster boot time on heroku.
