### PR TITLE
Changes to scoreboard to help small screens

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,8 +10,7 @@ need to do is `sudo apt-get install redis-server`).
 
 ```shell
 # Initial setup
-$ bundle install
-$ sh bootstrap.sh
+$ ./bin/setup
 $ npm install
 
 # Actual development (run simultaneously)
@@ -19,4 +18,3 @@ $ bundle exec rails s -p 2277
 $ bundle exec sidekiq
 $ npm run watch
 ```
-

--- a/app/assets/stylesheets/scoreboards/_show.scss
+++ b/app/assets/stylesheets/scoreboards/_show.scss
@@ -40,7 +40,7 @@ $bottom-bar-height: 120px;
 
 .scoreboard-player-score {
   position: absolute;
-  bottom: 0;
+  bottom: $bottom-bar-height;
   font-size: modular-scale(10);
   line-height: 1;
   text-shadow: 5px 5px 0 rgba(0, 0, 0, 0.15);

--- a/app/assets/stylesheets/scoreboards/_show.scss
+++ b/app/assets/stylesheets/scoreboards/_show.scss
@@ -91,6 +91,7 @@ $bottom-bar-height: 120px;
   line-height: 1.2;
   color: $off-white;
   text-shadow: 4px 4px 0 rgba(0, 0, 0, 0.25);
+  z-index: 1;
 }
 
 @-webkit-keyframes blinker {
@@ -117,6 +118,7 @@ $bottom-bar-height: 120px;
   line-height: 1.2;
   color: $yellow;
   text-shadow: 4px 4px 0 rgba(0, 0, 0, 0.25);
+  z-index: 1;
 
   -webkit-animation-name: blinker;
   -webkit-animation-iteration-count: infinite;

--- a/app/models/ping_pong/instructions.rb
+++ b/app/models/ping_pong/instructions.rb
@@ -3,6 +3,8 @@ module PingPong
     def message
       if match.finished? && !match.finalized?
         "Press to finalize"
+      elsif match.warmup?
+        "Waiting for match to start"
       elsif !match.first_service
         "Select first service"
       end

--- a/spec/features/scoreboard_spec.rb
+++ b/spec/features/scoreboard_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "scoreboard page" do
     expect(page).to have_content(home.name)
     expect(page).to have_content(away.name)
     expect(page).to have_content("01:30")
-    expect(page).to have_content("Select first service")
+    expect(page).to have_content("Waiting for match to start")
 
     table.home_button
     expect(page).to have_content("This is the first match between these players")


### PR DESCRIPTION
# Small Screen (Ipad)

<img width="961" alt="screen shot 2016-06-25 at 3 00 08 pm" src="https://cloud.githubusercontent.com/assets/1529452/16359344/8ca9be62-3ae5-11e6-8225-501c31e0cdb6.png">
# Large Screen (50% zoom)

<img width="1129" alt="screen shot 2016-06-25 at 3 00 55 pm" src="https://cloud.githubusercontent.com/assets/1529452/16359352/c1ec4ab8-3ae5-11e6-9d45-9bf38994846f.png">
