### PR TITLE
Add rack-cors gem, set CORS headers for API routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '2.3.1'
 gem 'mime-types', '~> 2.6.1', require: 'mime/types/columnar'
 
 gem 'rails', '~> 5.0.0'
+gem 'rack-cors'
 gem 'pg'
 gem 'puma'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,7 @@ GEM
       pry (>= 0.9.10)
     puma (3.4.0)
     rack (2.0.1)
+    rack-cors (0.4.0)
     rack-livereload (0.3.16)
       rack
     rack-mini-profiler (0.10.1)
@@ -326,6 +327,7 @@ DEPENDENCIES
   poltergeist
   pry-rails
   puma
+  rack-cors
   rack-livereload
   rack-mini-profiler
   rails (~> 5.0.0)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,8 @@
+Rails.application.config.middleware.insert_before 0, "Rack::Cors" do
+  allow do
+    origins "porkchop.club"
+    resource "/api/*",
+      headers: :any,
+      methods: %i[get post put delete options]
+  end
+end


### PR DESCRIPTION
As part of my plan to save jhawthorn $5/month in Cloudfront bills, I'd
like to switch the scoreboard and other AJAX-y API bits of the Porkchop
app to make requests against the Heroku app directly
(https://porkchop-prod.herokuapp.com). However, this currently won't
work since we don't set CORS headers.

Using the rack-cors middleware, we can set CORS headers as appropriate.
