### PR TITLE
Revert "API: Directly hit Heroku in production environment"

### DIFF
--- a/app/webpack/components/match_controls.js
+++ b/app/webpack/components/match_controls.js
@@ -1,60 +1,59 @@
 import $ from 'jquery'
 import Bacon from 'baconjs'
-import api from '../utils/api'
 $.fn.asEventStream = Bacon.$.asEventStream
 
 $(() => {
   if (!$('.match-controls').length) { return }
 
-  const ajaxOptions = { url: api('ongoing_match.json') }
+  const ajaxOptions = { url: '/api/ongoing_match.json' }
 
   const homePlayerPoints = $('.match-controls-home-player')
     .asEventStream('click')
     .map(() => {
       ga('send', 'event', 'button', 'click', 'home point')
-      return { url: api('ongoing_match/home_point.json'), type: 'PUT' }
+      return { url: '/api/ongoing_match/home_point.json', type: 'PUT' }
     })
 
   const awayPlayerPoints = $('.match-controls-away-player')
     .asEventStream('click')
     .map(() => {
       ga('send', 'event', 'button', 'click', 'away point')
-      return { url: api('ongoing_match/away_point.json'), type: 'PUT' }
+      return { url: '/api/ongoing_match/away_point.json', type: 'PUT' }
     })
 
   const serviceToggle = $('.match-controls-toggle-service')
     .asEventStream('click')
     .map(() => {
       ga('send', 'event', 'button', 'click', 'toggle service')
-      return { url: api('ongoing_match/toggle_service.json'), type: 'PUT' }
+      return { url: '/api/ongoing_match/toggle_service.json', type: 'PUT' }
     })
 
   const rewinds = $('.match-controls-rewind')
     .asEventStream('click')
     .map(() => {
       ga('send', 'event', 'button', 'click', 'rewind')
-      return { url: api('ongoing_match/rewind.json'), type: 'PUT' }
+      return { url: '/api/ongoing_match/rewind.json', type: 'PUT' }
     })
 
   const finalization = $('.match-controls-finalize-match')
     .asEventStream('click')
     .map(() => {
       ga('send', 'event', 'button', 'click', 'finalize match')
-      return { url: api('ongoing_match/finalize.json'), type: 'PUT' }
+      return { url: '/api/ongoing_match/finalize.json', type: 'PUT' }
     })
 
   const cancellations = $('.match-controls-cancel-match')
     .asEventStream('click')
     .map(() => {
       ga('send', 'event', 'button', 'click', 'cancel match')
-      return { url: api('ongoing_match.json'), type: 'DELETE' }
+      return { url: '/api/ongoing_match.json', type: 'DELETE' }
     })
 
   const matchmakes = $('.match-controls-matchmake')
     .asEventStream('click')
     .map(() => {
       ga('send', 'event', 'button', 'click', 'matchmake')
-      return { url: api('ongoing_match/matchmake.json'), type: 'PUT' }
+      return { url: '/api/ongoing_match/matchmake.json', type: 'PUT' }
     })
 
   const data = Bacon

--- a/app/webpack/components/player_activations.js
+++ b/app/webpack/components/player_activations.js
@@ -1,7 +1,6 @@
 import $ from 'jquery'
 import Bacon from 'baconjs'
 import { filter } from 'lodash'
-import api from '../utils/api'
 $.fn.asEventStream = Bacon.$.asEventStream
 
 $(() => {
@@ -10,20 +9,20 @@ $(() => {
   const activePlayerList = $('.active-players-list')
   const inactivePlayerList = $('.inactive-players-list')
 
-  const initialFetch = Bacon.once({ url: api('activations') })
+  const initialFetch = Bacon.once({ url: '/api/activations' })
 
   const activations = inactivePlayerList
     .asEventStream('click', 'li')
     .map((event) => {
       const id = $(event.target).data('id')
-      return { url: api(`activations/${id}/activate.json`), type: 'PUT' }
+      return { url: `/api/activations/${id}/activate.json`, type: 'PUT' }
     })
 
   const deactivations = activePlayerList
     .asEventStream('click', 'li')
     .map((event) => {
       const id = $(event.target).data('id')
-      return { url: api(`activations/${id}/deactivate.json`), type: 'PUT' }
+      return { url: `/api/activations/${id}/deactivate.json`, type: 'PUT' }
     })
 
   const allPlayers = Bacon.mergeAll([initialFetch, activations, deactivations])

--- a/app/webpack/observables/ongoingMatch.js
+++ b/app/webpack/observables/ongoingMatch.js
@@ -1,5 +1,4 @@
 import { ajaxPoll } from 'baconjs'
-import api from '../utils/api'
 
 const EMPTY_MATCH = {
   home_score: '',
@@ -18,7 +17,7 @@ const EMPTY_MATCH = {
   warmup: false,
 }
 
-const ajaxOptions = { url: api('ongoing_match.json') }
+const ajaxOptions = { url: '/api/ongoing_match.json' }
 const matchPolls = ajaxPoll(ajaxOptions, 300)
 
 export default matchPolls

--- a/app/webpack/utils/api.js
+++ b/app/webpack/utils/api.js
@@ -1,9 +1,0 @@
-/* eslint no-else-return: "off" */
-export default function(endpoint) {
-  if (process.env.NODE_ENV === 'production') {
-    // API requests should hit heroku directly in prod, avoiding Cloudfront
-    return `https://porkchop-prod.herokuapp.com/api/${endpoint}`
-  } else {
-    return `/api/${endpoint}`
-  }
-}

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -4,9 +4,5 @@ end
 
 task :webpack do
   sh "npm install"
-  if Rails.env.production?
-    sh "NODE_ENV=production npm run compile"
-  else
-    sh "npm run compile"
-  end
+  sh "npm run compile"
 end

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,14 +21,6 @@ module.exports = function(options) {
     })
   ];
 
-  if (process.env.NODE_ENV === "production") {
-    config.plugins.push(
-      new webpack.DefinePlugin({
-        'process.env': { 'NODE_ENV': JSON.stringify('production') }
-      })
-    );
-  }
-
   config.module = {
     loaders: [
       { test: /\.js$/,


### PR DESCRIPTION
Reverts porkchopclub/porkchop#60

Because the api endpoint used isn't a subdomain, we can't do this (because the cookie based session gets lost.)
