### PR TITLE
Configure redis expiry

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
-  config.cache_store = :redis_store, ENV['REDIS_PROVIDER']
+  config.cache_store = :redis_store, ENV['REDIS_PROVIDER'], { expires_in: 2.days }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
By default redis uses volatile-lru, which won't expire keys without a
timeout. This is undesirable for cache, so we set a default of 2 days.
