### PR TITLE
Remove text-decoration from header

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -24,6 +24,7 @@ $header-padding: 20px;
     a {
       font-weight: bold;
       color: #fff;
+      text-decoration: none;
 
       span {
         font-size: 16px;


### PR DESCRIPTION
This looks odd since it has two font sizes.

Fixes #13
