### PR TITLE
Variable polling rate

### DIFF
--- a/app/webpack/api/matches.js
+++ b/app/webpack/api/matches.js
@@ -48,7 +48,9 @@ const deserializeMatch = (json) => {
 }
 /* eslint-enable no-param-reassign */
 
-export const ongoingMatch = (tableId, interval) => {
+export const ongoingMatch = (tableId) => {
+  let lastTimeSucceeded = Date.now()
+
   const callbacks = []
   const notifyCallbacks = (value) =>
     callbacks.forEach((callback) => callback(value))
@@ -56,6 +58,7 @@ export const ongoingMatch = (tableId, interval) => {
     // eslint-disable-next-line no-use-before-define
     refetchOngoingMatch()
     notifyCallbacks(value)
+    if (value) lastTimeSucceeded = Date.now()
   }
   const handleFailure = (error) => {
     // eslint-disable-next-line no-use-before-define
@@ -69,7 +72,20 @@ export const ongoingMatch = (tableId, interval) => {
       .then(deserializeMatch)
       .then(handleSuccess)
       .catch(handleFailure)
-  const refetchOngoingMatch = () => setTimeout(fetchOngoingMatch, interval)
+  const refetchOngoingMatch = () => {
+    const secondsPassed = (Date.now() - lastTimeSucceeded) / 1000
+    let interval
+    if (secondsPassed > 120) {
+      interval = 10000
+    } else if (secondsPassed > 60) {
+      interval = 1000
+    } else if (secondsPassed > 30) {
+      interval = 250
+    } else {
+      interval = 50
+    }
+    setTimeout(fetchOngoingMatch, interval)
+  }
 
   fetchOngoingMatch()
 

--- a/app/webpack/components/Scoreboard.js
+++ b/app/webpack/components/Scoreboard.js
@@ -9,7 +9,7 @@ import { ongoingMatch } from '../api/matches'
 
 class Scoreboard extends Component {
   componentDidMount() {
-    ongoingMatch(this.props.tableId, 300)
+    ongoingMatch(this.props.tableId)
       .subscribe((match) => {
         this.setState((previousState) => {
           const newState = { ...previousState }


### PR DESCRIPTION
Here's my napkin math:

```
At old rate:
1000/300 * 60 * 60 * 24 = 288000 requests/day

New rate under load (for 3 hours)
1000/50 * 60 * 60 * 3 = 216000 requests

New rate under no load (for 21 hours)
1000/10000 * 60 * 60 * 21 = 7560 requests

Total requests/day under new rate: 223560
```

Given that we rarely ever play 3 hours a day, and also weekends, this should reduce the number of requests substantially.
