### PR TITLE
Turn on UglifyJS for production

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -11,6 +11,7 @@ module.exports = merge(sharedConfig.config, {
   plugins: [
     new webpack.LoaderOptionsPlugin({
       minimize: true
-    })
+    }),
+    new webpack.optimize.UglifyJsPlugin()
   ]
 })


### PR DESCRIPTION
What does it do?
----------------
Turns on minifaction of JS.

I'm not sure if we lost this when switching to webpacker, or earlier.

How does it work?
-----------------
Adds `new webpack.optimize.UglifyJsPlugin()` to the `webpack/production.js` config.

Anything to consider when deploying?
------------------------------------
:shipit: 
