### PR TITLE
Fix players show page

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -8,7 +8,7 @@ class PlayersController < ApplicationController
 
   def show
     @stats = Stats::Personal.new(@player)
-    @javascript_entrypoint = "player_show"
+    @javascript_entrypoint = "playerShow"
   end
 
   private

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,10 +9,5 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 Rails.application.config.assets.precompile += %w(
-  default.js
-  homepage.js
-  legacy_scoreboard.js
-  player_show.js
   scoreboard.css
-  scoreboard.js
 )

--- a/spec/features/player_show_spec.rb
+++ b/spec/features/player_show_spec.rb
@@ -1,0 +1,13 @@
+require 'feature_helper'
+
+RSpec.describe "scoreboard page", js: true do
+  let!(:player) { create :player, name: "Candice Bergen" }
+
+  scenario "viewing player page" do
+    visit player_path(player)
+
+    expect(page).to have_content(player.name)
+    expect(page).to have_content("Elo: 1000")
+    expect(page).to have_content("This player hasn't even played a game yet.")
+  end
+end


### PR DESCRIPTION
What does it do?
----------------
Fixes the players show page and adds a spec.

How does it work?
-----------------
The players show page was broken because the existing webpack config mapped `player_show` to `playerShow`. We now map the names directly, so I should have updated this when switching to webpacker.

Anything to consider when deploying?
------------------------------------
:shipit: 

Screenshots (Optional)
----------------------
