### PR TITLE
Order next match players

### DIFF
--- a/app/serializers/matchup_serializer.rb
+++ b/app/serializers/matchup_serializer.rb
@@ -2,6 +2,21 @@ class MatchupSerializer < ActiveModel::Serializer
   attribute :player_names
 
   def player_names
-    object.players.map(&:name)
+    ordered_players.map(&:name)
+  end
+
+  private
+
+  attr_reader :player1, :player2
+
+  def ordered_players
+    @player1, @player2 = *object.players.sort_by(&:name)
+    player1_at_home? ? [player1, player2] : [player2, player1]
+  end
+
+  def player1_at_home?
+    player1_at_home = player1.matches_against(player2).none? ||
+                      player1.matches_against(player2).
+                      order(created_at: :asc).last.away_player == player1
   end
 end

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "porkchop",
   "version": "1.2.3",
   "engines": {
-    "node": "6.3.0",
+    "node": ">=6.3.0",
     "npm": "3.10.x"
   },
   "private": true,

--- a/spec/serializers/matchup_serializer_spec.rb
+++ b/spec/serializers/matchup_serializer_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe MatchupSerializer do
+  describe "#player_names" do
+    subject { described_class.new(matchup).player_names }
+
+    let(:jessica) { create :player, name: "Jessica Jones" }
+    let(:luke) { create :player, name: "Luke Cage" }
+    let(:matchup) { Matchup.new(jessica, luke) }
+
+    context "when two players have never played against each other" do
+      it "displays players in alphabetical order" do
+        expect(subject).to eq ["Jessica Jones", "Luke Cage"]
+      end
+    end
+
+    context "when Jessica Jones should be the home player" do
+      before do
+        create(
+          :complete_match,
+          home_player: luke,
+          away_player: jessica,
+          finalized_at: 1.week.ago
+        )
+      end
+
+      it "returns Jessica Jones as the first player" do
+        expect(subject).to eq ["Jessica Jones", "Luke Cage"]
+      end
+    end
+
+    context "when Jessica Jones should be the away player" do
+      before do
+        create(
+          :match,
+          home_player: jessica,
+          away_player: luke,
+          finalized_at: 2.weeks.ago
+        )
+      end
+
+      it "returns Luke Cage as the first player" do
+        expect(subject).to eq ["Luke Cage", "Jessica Jones"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
What does it do?
----------------
Orders players by which side of the table they should be playing on.

How does it work?
-----------------
Modified the `MatchupSerializer` by borrowing some code from `Match`.

Anything to consider when deploying?
------------------------------------
No way, Jose.