### PR TITLE
A few fixes before I go!

### DIFF
--- a/app/javascript/components/scoreboard/OngoingMatch.js
+++ b/app/javascript/components/scoreboard/OngoingMatch.js
@@ -10,7 +10,6 @@ const playerStyle = (player, match) => ({
   backgroundImage: `url(${match[`${player}_player`].portrait_url})`
 })
 
-const nextMatchPlayers = (match) => match.next_matchup.player_names.join(" vs ")
 const centerText = (match) => {
   if (match['finished?']) {
     return "Final Score"
@@ -39,10 +38,6 @@ export default ({ match }) => {
         </div>
 
         <div className="ongoing-match-versus">{centerText(match)}</div>
-      </div>
-
-      <div className="ongoing-match-next-match">
-        Next up: {nextMatchPlayers(match)}
       </div>
     </div>
   )

--- a/app/javascript/components/scoreboard/Scoreboard.js
+++ b/app/javascript/components/scoreboard/Scoreboard.js
@@ -21,6 +21,8 @@ const mapStateToProps = (state) => {
   }
 }
 
+const nextMatchPlayers = (match) => match.next_matchup.player_names.join(" vs ")
+
 const visibleComponent = (props) => {
   const {
     isMatchHappening,
@@ -40,6 +42,10 @@ const visibleComponent = (props) => {
 const Scoreboard = (props) =>  (
   <div className="scoreboard">
     {visibleComponent(props)}
+
+    {ongoingMatch && <div className="ongoing-match-next-match">
+      Next up: {nextMatchPlayers(props.ongoingMatch)}
+    </div>}
   </div>
 )
 

--- a/app/javascript/components/scoreboard/Scoreboard.js
+++ b/app/javascript/components/scoreboard/Scoreboard.js
@@ -41,7 +41,7 @@ const nextMatchPlayers = (match) => match && match.next_matchup.player_names
 const nextUpText = (players) => players.length ? `Next up: ${players.join(" vs ")}` : "No upcoming match."
 
 const Scoreboard = (props) => {
-  const players = nextMatchPlayers(props.ongoingMatch)
+  const players = nextMatchPlayers(props.ongoingMatch) || []
 
   return (
     <div className="scoreboard">

--- a/app/javascript/components/scoreboard/Scoreboard.js
+++ b/app/javascript/components/scoreboard/Scoreboard.js
@@ -21,8 +21,6 @@ const mapStateToProps = (state) => {
   }
 }
 
-const nextMatchPlayers = (match) => match.next_matchup.player_names.join(" vs ")
-
 const visibleComponent = (props) => {
   const {
     isMatchHappening,
@@ -39,14 +37,21 @@ const visibleComponent = (props) => {
   return <OngoingMatch match={ongoingMatch}/>
 }
 
-const Scoreboard = (props) =>  (
-  <div className="scoreboard">
-    {visibleComponent(props)}
+const nextMatchPlayers = (match) => match && match.next_matchup.player_names
+const nextUpText = (players) => players.length ? `Next up: ${players.join(" vs ")}` : "No upcoming match."
 
-    {ongoingMatch && <div className="ongoing-match-next-match">
-      Next up: {nextMatchPlayers(props.ongoingMatch)}
-    </div>}
-  </div>
-)
+const Scoreboard = (props) => {
+  const players = nextMatchPlayers(props.ongoingMatch)
+
+  return (
+    <div className="scoreboard">
+      {visibleComponent(props)}
+
+      <div className="ongoing-match-next-match">
+        {nextUpText(players)}
+      </div>
+    </div>
+  )
+}
 
 export default connect(mapStateToProps)(Scoreboard)

--- a/app/javascript/components/scoreboard/Scoreboard.js
+++ b/app/javascript/components/scoreboard/Scoreboard.js
@@ -30,10 +30,6 @@ const visibleComponent = (props) => {
   } = props
   if (!isMatchHappening) { return <NoMatch/> }
 
-  // FIXME:
-  // if (!isMatchStarted && secondsOld < 30) {
-  //   return <MatchResult/>
-  // } else
   if (!isMatchStarted && secondsOld < 90) {
     return <MatchPreview/>
   }

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -47,11 +47,13 @@ class Player < ActiveRecord::Base
     end
   end
 
-  def matches_against(opponent)
-    matches.finalized.where(
+  def matches_against(opponent, finalized: true)
+    query = matches.where(
       "away_player_id = :opponent OR home_player_id = :opponent",
       opponent: opponent
     )
+    query = query.finalized if finalized
+    query
   end
 
   def opponents

--- a/app/serializers/betting_info_serializer.rb
+++ b/app/serializers/betting_info_serializer.rb
@@ -2,6 +2,6 @@ class BettingInfoSerializer < ActiveModel::Serializer
   attributes :spread
 
   def spread
-    [object.favourite.name, object.spread].join(" +")
+    [object.favourite.name, object.spread].join(" ")
   end
 end

--- a/app/serializers/matchup_serializer.rb
+++ b/app/serializers/matchup_serializer.rb
@@ -17,8 +17,8 @@ class MatchupSerializer < ActiveModel::Serializer
 
   def player1_at_home?
     return false unless object.players.any?
-    player1_at_home = player1.matches_against(player2).none? ||
-                      player1.matches_against(player2).
+    player1_at_home = player1.matches_against(player2, finalized: false).none? ||
+                      player1.matches_against(player2, finalized: false).
                       order(created_at: :asc).last.away_player == player1
   end
 end

--- a/app/services/betting/spread.rb
+++ b/app/services/betting/spread.rb
@@ -12,7 +12,7 @@ module Betting
 
     def spread
       return if match_count < Betting::MINIMUM_MATCH_COUNT
-      (raw_spread.abs - 0.5).round + 0.5
+      -((raw_spread.abs - 0.5).round + 0.5)
     end
 
     def favourite

--- a/spec/services/betting/spread_spec.rb
+++ b/spec/services/betting/spread_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Betting::Spread do
       end
 
       it "calculates the spread" do
-        expect(calculator.spread).to eq 0.5
+        expect(calculator.spread).to eq -0.5
         expect(calculator.favourite).to eq adam
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe Betting::Spread do
       end
 
       it "calculates the spread" do
-        expect(calculator.spread).to eq 0.5
+        expect(calculator.spread).to eq -0.5
         expect(calculator.favourite).to eq jared
       end
     end


### PR DESCRIPTION
This fixes a few longstanding gripes:

1. The upcoming matchup now shows on the match preview (aka "warm up") screen.
2. Match preview now shows spread as a negative number (we technically should make all the historical values negative, but they don't show anywhere, so that can be done later.)
3. The upcoming matchup now shows in the correct number even if it's the same players as the ongoing match.